### PR TITLE
Fill the gap test styled

### DIFF
--- a/src/pods/test-fill-gap/components/components.styles.ts
+++ b/src/pods/test-fill-gap/components/components.styles.ts
@@ -1,0 +1,135 @@
+import { css } from 'emotion';
+import { theme } from "core/theme";
+
+const { palette, spacing, breakpoints } = theme;
+const color = palette.customPalette;
+
+export const backContainer = css`
+  margin-top: ${spacing(19)};
+  margin-bottom: ${spacing(6)};
+  padding: ${spacing(10)} ${spacing(5)} ${spacing(1)};
+  height: 26rem;
+  position: relative;
+  background-color: ${color.lightWhite};
+  border-radius: 2rem;
+`;
+
+export const insideBtnContainer = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 80%;
+`;
+
+export const insideBtn = css`
+  text-align: center;
+`;
+
+export const insideRightAnswer = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+`;
+
+export const buttonRight = css`
+  text-align: center;
+  border-radius: 1.4rem;
+  width: ${spacing(20)};
+  margin: ${spacing(4)} auto 0 auto;
+  padding: ${spacing(2.5)} ${spacing(3)};
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  text-transform: capitalize;
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: ${color.lightWhite};
+  background-color: #33cc33;
+  transition: all 0.2s;
+  --webkit-transition: all 0.2s;
+  @media (min-width: ${breakpoints.values.xs}px) {
+    width: ${spacing(30)};
+    justify-content: flex-end;
+  }
+`;
+
+export const buttonWrong = css`
+  border-radius: 1.4rem;
+  width: ${spacing(20)};
+  margin: ${spacing(4)} auto 0 auto;
+  padding: ${spacing(2)} ${spacing(3)};
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  text-transform: capitalize;
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: ${color.lightWhite};
+  background-color: ${color.primaryMain};
+  transition: all 0.2s;
+  --webkit-transition: all 0.2s;
+  @media (min-width: ${breakpoints.values.xs}px) {
+    width: ${spacing(30)};
+    justify-content: flex-end;
+  }
+`;
+
+export const picture = css`
+  max-width: 100%;
+  margin-top: 1.5rem;
+`;
+
+export const pictureContainer = css`
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: ${color.lightWhite};
+  width: 10rem;
+  padding: 1rem;
+  margin: 0 auto;
+  border-radius: 2rem;
+  -webkit-box-shadow: 2px 3px 23px 5px rgba(140, 140, 140, 0.38);
+  box-shadow: 2px 3px 23px 5px rgba(140, 140, 140, 0.38);
+  @media (min-width: ${breakpoints.values.xs}px) {
+    width: 12rem;
+  }
+`;
+
+export const answer = css`
+  display: block;
+  font-size: 2rem;
+  font-weight: 800;
+  margin: 1rem;
+  text-align: center;
+  text-decoration: underline;
+`;
+
+export const verbsForm = css`
+  display: block;
+  font-size: 1.3rem;
+  font-weight: 500;
+`;
+
+export const inputField = css`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  & label {
+    font-size: 1.1rem;
+
+    font-weight: 700;
+  }
+
+  & input {
+    font-family: inherit;
+    border: none;
+    border-bottom: 2px solid ${color.dark};
+    background-color: ${color.lightWhite};
+    padding: ${spacing(1)};
+    font-size: 1.1rem;
+    &:hover,
+    &:active,
+    &:focus {
+      outline: none;
+      border-bottom: 2px solid ${color.lightBlue};
+    }
+  }
+`;

--- a/src/pods/test-fill-gap/components/gap.component.tsx
+++ b/src/pods/test-fill-gap/components/gap.component.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import Typography from "@material-ui/core/Typography";
-import { TextFieldComponent } from 'common/components';
+import { Field } from "formik";
+import * as styles from './components.styles';
 
 interface Props {
   isGap: boolean;
@@ -10,11 +10,18 @@ interface Props {
 
 export const GapComponent: React.FC<Props> = props => {
   const { isGap, text, tense } = props;
+  const { inputField, verbsForm } = styles;
   return isGap ? (
-    <TextFieldComponent name="response" label={tense} />
+    <div className={inputField}>
+      <label>{tense}</label>
+      <Field
+        type="text"
+        name="response"
+        id="response"
+        autoComplete="off"
+      />
+    </div>
   ) : (
-    <Typography variant="subtitle1">
-      {tense}: {text}
-    </Typography>
+    <span className={verbsForm}>{tense}: {text}</span>
   );
 }

--- a/src/pods/test-fill-gap/components/show-results.component.tsx
+++ b/src/pods/test-fill-gap/components/show-results.component.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Verb } from '../test-fill-gap.vm';
+import * as styles from './components.styles';
 
 interface Props {
   isCorrect: boolean;
@@ -8,12 +9,55 @@ interface Props {
 
 export const ShowResultsComponent: React.FC<Props> = props => {
   const { isCorrect, verb } = props;
-  return isCorrect ? (
-    <span>RIGHT !!!!</span>
-  ) : (
-    <span>
-      Right answer:{' '}
-      {`${verb.infinitive} / ${verb.past} /${verb.participle} / ${verb.translation}`}
-    </span>
+  const {
+    backContainer,
+    pictureContainer,
+    picture,
+    buttonRight,
+    insideRightAnswer,
+    buttonWrong,
+    verbsForm,
+    answer,
+    insideBtn,
+  } = styles;
+
+  return (
+    <div className={backContainer}>
+      <div className={pictureContainer}>
+        <img
+          className={picture}
+          src={`/assets/verb-images/${verb.infinitive}.png`}
+        />
+      </div>
+      {isCorrect ? (
+        <div className={insideRightAnswer}>
+          <div className={buttonRight}>
+            <span>RIGHT !!!!</span>
+          </div>
+          <div>
+            <img
+              className={picture}
+              src={`/assets/right-answer/right.png`}
+              alt=""
+            />
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className={buttonWrong}>
+            <div className={insideBtn}>
+              <span>Oops... nope</span>
+            </div>
+          </div>
+          <div>
+            <span className={answer}>Answer</span>
+            <span className={verbsForm}>Infinite: {verb.infinitive}</span>
+            <span className={verbsForm}>Past: {verb.past}</span>
+            <span className={verbsForm}>participle: {verb.participle}</span>
+            <span className={verbsForm}>translation: {verb.translation}</span>
+          </div>
+        </>
+      )}
+    </div>
   );
 };

--- a/src/pods/test-fill-gap/test-fill-gap.component.tsx
+++ b/src/pods/test-fill-gap/test-fill-gap.component.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
+import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import { Verb, VerbTenses, VerbQuiz, createDefaultVerbQuiz } from "./test-fill-gap.vm";
 import { Formik, Form } from 'formik';
 import { GapComponent, ShowResultsComponent } from './components';
 import { answerIsCorrect } from './test-fill-gap.business';
+import * as styles from './test-fill-gap.styles';
 
 interface Props {
   currentQuestion: number;
@@ -32,6 +34,18 @@ export const TestFillGapComponent: React.FC<Props> = props => {
     createDefaultVerbQuiz()
   );
 
+  const {
+    title,
+    mainContainer,
+    inputContainer,
+    backContainer,
+    pictureContainer,
+    picture,
+    insideBtnContainer,
+    nextBtn,
+    arrowIcon,
+  } = styles;
+
   const handleValidateAnswer = (isCorrect: boolean) => {
     if (isCorrect) {
       setScore(score + 1);
@@ -46,8 +60,10 @@ export const TestFillGapComponent: React.FC<Props> = props => {
   }
 
   return (
-    <div>
-      <h1>Question {`${currentQuestion} / ${totalQuestions}`}</h1>
+    <main className={mainContainer}>
+      <h1 className={title}>
+        {verb.translation} ({`${currentQuestion} / ${totalQuestions}`})
+      </h1>
       <Formik
         onSubmit={(values, actions) => {
           const isCorrect = answerIsCorrect(verb, values);
@@ -61,25 +77,30 @@ export const TestFillGapComponent: React.FC<Props> = props => {
         {() => (
           <Form>
             {!validated && (
-              <div>
-                <Typography variant="subtitle1">
-                  Translation: {verb.translation}
-                </Typography>
-                <GapComponent
-                  isGap={initialQuiz.tense === VerbTenses.infinitive}
-                  text={verb.infinitive}
-                  tense={"Infinitive"}
-                />
-                <GapComponent
-                  isGap={initialQuiz.tense === VerbTenses.past}
-                  text={verb.past}
-                  tense={"Past"}
-                />
-                <GapComponent
-                  isGap={initialQuiz.tense === VerbTenses.participle}
-                  text={verb.participle}
-                  tense={"Participle"}
-                />
+              <div className={backContainer}>
+                <div className={pictureContainer}>
+                  <img
+                    className={picture}
+                    src={`/assets/verb-images/${verb.infinitive}.png`}
+                  />
+                </div>
+                <div className={inputContainer}>
+                  <GapComponent
+                    isGap={initialQuiz.tense === VerbTenses.infinitive}
+                    text={verb.infinitive}
+                    tense={"Infinitive"}
+                  />
+                  <GapComponent
+                    isGap={initialQuiz.tense === VerbTenses.past}
+                    text={verb.past}
+                    tense={"Past"}
+                  />
+                  <GapComponent
+                    isGap={initialQuiz.tense === VerbTenses.participle}
+                    text={verb.participle}
+                    tense={"Participle"}
+                  />
+                </div>
               </div>
             )}
             {validated ? (
@@ -87,21 +108,31 @@ export const TestFillGapComponent: React.FC<Props> = props => {
                 <ShowResultsComponent isCorrect={isCorrect} verb={verb} />
 
                 <Button
+                  className={nextBtn}
                   onClick={internalHandleOnNextQuestion}
                   variant="contained"
-                  color="primary"
                 >
-                  Next verb
+                  <div className={insideBtnContainer}>
+                    <span>Next Verb</span>
+                    <ArrowForwardIcon className={arrowIcon} />
+                  </div>
                 </Button>
               </>
             ) : (
-                <Button type="submit" variant="contained" color="primary">
-                  Validate
+                <Button
+                  className={nextBtn}
+                  type="submit"
+                  variant="contained"
+                  disableElevation
+                >
+                  <div className={insideBtnContainer}>
+                    Next <ArrowForwardIcon className={arrowIcon} />
+                  </div>
                 </Button>
               )}
           </Form>
         )}
       </Formik>
-    </div>
+    </main>
   )
 };

--- a/src/pods/test-fill-gap/test-fill-gap.styles.ts
+++ b/src/pods/test-fill-gap/test-fill-gap.styles.ts
@@ -1,0 +1,103 @@
+import { css } from 'emotion';
+import { theme } from "core/theme";
+
+const { palette, spacing, breakpoints } = theme;
+const color = palette.customPalette;
+
+export const mainContainer = css`
+  width: 90%;
+  @media (min-width: ${breakpoints.values.xs}px) {
+    width: 70%;
+  }
+  @media (min-width: ${breakpoints.values.sm}px) {
+    max-width: 24rem;
+  }
+`;
+
+export const title = css`
+  margin-top: ${spacing(4)};
+  font-size: 1.6rem;
+  text-align: center;
+  @media (min-width: ${breakpoints.values.xs}px) {
+    font-size: 1.75rem;
+  }
+`;
+
+export const backContainer = css`
+  margin-top: ${spacing(19)};
+  margin-bottom: ${spacing(6)};
+  padding: ${spacing(10)} ${spacing(5)} ${spacing(1)};
+  height: 26rem;
+  position: relative;
+  background-color: ${color.lightWhite};
+  border-radius: 2rem;
+`;
+
+export const pictureContainer = css`
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: ${color.lightWhite};
+  width: 10rem;
+  padding: 1rem;
+  margin: 0 auto;
+  border-radius: 2rem;
+  -webkit-box-shadow: 2px 3px 23px 5px rgba(140, 140, 140, 0.38);
+  box-shadow: 2px 3px 23px 5px rgba(140, 140, 140, 0.38);
+  @media (min-width: ${breakpoints.values.xs}px) {
+    width: 12rem;
+  }
+`;
+
+export const picture = css`
+  max-width: 100%;
+`;
+
+export const inputContainer = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding-top: ${spacing(4)};
+  height: 85%;
+`;
+
+export const insideBtnContainer = css`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 80%;
+`;
+
+export const nextBtn = css`
+  display: flex;
+  justify-content: center;
+  border-radius: 1.4rem;
+  width: ${spacing(20)};
+  margin: ${spacing(4)} auto 0 auto;
+  padding: ${spacing(1.5)} ${spacing(3)};
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  text-transform: capitalize;
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: ${color.lightWhite};
+  background-color: ${color.primaryMain};
+  transition: all 0.2s;
+  --webkit-transition: all 0.2s;
+  &:hover,
+  &:active {
+    outline: none;
+    background-color: ${color.primaryDark};
+  }
+  @media (min-width: ${breakpoints.values.xs}px) {
+    width: ${spacing(30)};
+    justify-content: flex-end;
+  }
+`;
+
+export const arrowIcon = css`
+  margin-left: ${spacing(1)};
+  font-size: 1.4rem;
+  @media (min-width: ${breakpoints.values.xs}px) {
+    margin-left: auto;
+  }
+`;

--- a/src/scenes/test-fill-gap.scene.tsx
+++ b/src/scenes/test-fill-gap.scene.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
+import { AppLayout } from "layout";
 import { TestFillGapContainer } from "pods/test-fill-gap";
 
 export const TestFillGapScene: React.FC = () => {
-  return <TestFillGapContainer />
+  return (
+    <AppLayout background={'light'}>
+      <TestFillGapContainer />
+    </AppLayout>
+  );
 };


### PR DESCRIPTION
Pull request for issue [31](https://github.com/Lemoncode/english-quiz/issues/31) - Style fill the gap test.
The same approach of tenses test has been applied to this one:
![image](https://user-images.githubusercontent.com/33926302/112573248-2d7e9200-8dec-11eb-8254-5d1e392c9c71.png)

Anyways, I think we should move to common or core styles used in this test (__src/pods/test-fill-gap/test-fill-gap.styles.ts__ and __src/pods/test-fill-gap/components/components.styles.ts__) and styles applied on tenses test.

If you have any doubts or you think I should change anything, please tell me.