### PR TITLE
Pronunciation integrated

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-dom": "^16.12.0",
     "react-hot-loader": "^4.12.18",
     "react-router-dom": "^5.2.0",
+    "react-speech-kit": "^3.0.1",
     "regenerator-runtime": "^0.13.3"
   },
   "devDependencies": {

--- a/src/common/components/index.ts
+++ b/src/common/components/index.ts
@@ -1,1 +1,2 @@
 export * from './form';
+export * from './pronunciation';

--- a/src/common/components/pronunciation/index.ts
+++ b/src/common/components/pronunciation/index.ts
@@ -1,0 +1,1 @@
+export * from './pronunciation.component';

--- a/src/common/components/pronunciation/pronunciation.business.spec.tsx
+++ b/src/common/components/pronunciation/pronunciation.business.spec.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { getAmericanVoices, getBritishVoices } from './pronunciation.business';
+
+describe('Pronunciation business specs', () => {
+  it('Should return an empty array if there´s no American voices', () => {
+    //Arrange
+    let noAmericanArray = [
+      { lang: 'es-ES' },
+      { lang: 'pt-BR' },
+      { lang: 'ru-RU' },
+      { lang: 'en-GB' },
+    ];
+    //Assert
+    let result = getAmericanVoices(noAmericanArray);
+
+    //Act
+    expect(result.length).toBe(0);
+  });
+
+  it('Should return an empty array if there´s no British voices', () => {
+    //Arrange
+    let noBritshArray = [
+      { lang: 'es-ES' },
+      { lang: 'pt-BR' },
+      { lang: 'ru-RU' },
+      { lang: 'en-US' },
+    ];
+    //Assert
+    let result = getBritishVoices(noBritshArray);
+
+    //Act
+    expect(result.length).toBe(0);
+  });
+
+  it('Should return an array composed by two elements when there are two American voices', () => {
+    //Arrange
+    let aux = [
+      { lang: 'en-AU' },
+      { lang: 'en-US' },
+      { lang: 'en-GB' },
+      { lang: 'en-US' },
+    ];
+    //Assert
+    let result = getAmericanVoices(aux);
+
+    //Act
+    expect(result.length).toBe(2);
+  });
+
+  it('Should return an array composed by one element when there is one British voice', () => {
+    //Arrange
+    let aux = [
+      { lang: 'en-AU' },
+      { lang: 'en-US' },
+      { lang: 'en-GB' },
+      { lang: 'en-CA' },
+    ];
+    //Assert
+    let result = getBritishVoices(aux);
+
+    //Act
+    expect(result.length).toBe(1);
+  });
+});

--- a/src/common/components/pronunciation/pronunciation.business.ts
+++ b/src/common/components/pronunciation/pronunciation.business.ts
@@ -1,0 +1,11 @@
+const getEnglishVoices = (
+  version: string,
+  voices
+) => {
+  return voices.filter(voice => {
+    return voice.lang === version;
+  });
+};
+
+export const getBritishVoices = voices => getEnglishVoices('en-GB', voices);
+export const getAmericanVoices = voices => getEnglishVoices('en-US', voices);

--- a/src/common/components/pronunciation/pronunciation.component.tsx
+++ b/src/common/components/pronunciation/pronunciation.component.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import IconButton from '@material-ui/core/IconButton';
+import VolumeUpIcon from '@material-ui/icons/VolumeUp';
+import { useSpeechSynthesis } from 'react-speech-kit';
+import { getBritishVoices } from './pronunciation.business';
+import * as styles from './pronunciation.styles';
+interface Props {
+  text: String;
+}
+
+const VOICE_RATE = 0.8; // Could be configured by user in future versions
+const VOICE_PITCH = 1; // Could be configured by user in future versions
+
+export const Pronunciation: React.FC<Props> = props => {
+  const { text } = props;
+  const { speak, voices, supported, speaking } = useSpeechSynthesis();
+  const [ englishVoices, setEnglishVoices ] = React.useState([]);
+  const {
+    pronunciationContainer,
+    volumeIcon,
+  } = styles;
+
+  React.useEffect(() => {
+    // Voices version (GB, US, AU, etc) could be configured by user in future versions
+    setEnglishVoices(getBritishVoices(voices)); 
+  }, [voices]);
+
+  const handleSpeak = () => {
+    if (!speaking) {
+      speak({
+        text,
+        voice: englishVoices[0], // Selected voice could be configured by user in future versions
+        rate: VOICE_RATE,
+        pitch: VOICE_PITCH,
+      });
+    }
+  };
+
+  return (
+    <>
+      {supported && englishVoices.length !== 0 && (
+        <div className={pronunciationContainer}>
+          <IconButton
+            className={volumeIcon}
+            onClick={() => handleSpeak()}
+          >
+            <VolumeUpIcon />
+          </IconButton>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/common/components/pronunciation/pronunciation.styles.ts
+++ b/src/common/components/pronunciation/pronunciation.styles.ts
@@ -1,0 +1,27 @@
+import { css } from 'emotion';
+import { theme } from 'core/theme';
+
+const { palette, spacing, breakpoints } = theme;
+const color = palette.customPalette;
+
+export const pronunciationContainer = css`
+  display: flex;
+  justify-content: center;  
+  padding-top: ${spacing(4)};
+`;
+
+export const volumeIcon = css`
+  width: ${spacing(4)};
+  color: ${color.lightWhite};
+  background-color: ${color.volumeLight};
+  transition: all 0.2s;
+  --webkit-transition: all 0.2s;
+  &:hover,
+  &:active {
+    outline: none;
+    background-color: ${color.volumeDark};
+  }
+  @media (min-width: ${breakpoints.values.xs}px) {
+    width: ${spacing(6)};
+  }
+`;

--- a/src/core/theme/theme.ts
+++ b/src/core/theme/theme.ts
@@ -24,6 +24,8 @@ export const theme: Theme = merge(defaultTheme, {
       lightPink: '#fbf5ff',
       lightBlue: '#4ca3c7',
       dark: '#1d3e4c',
+      volumeLight: '#007C45',
+      volumeDark: '#536F00',
     },
   },
   breakpoints: {

--- a/src/core/theme/theme.vm.ts
+++ b/src/core/theme/theme.vm.ts
@@ -11,6 +11,8 @@ interface Palette extends DefaultPalette {
     lightYellow: string;
     lightBlue: string;
     dark: string;
+    volumeLight: string;
+    volumeDark: string;
   };
 }
 

--- a/src/pods/test-fill-gap/test-fill-gap.component.tsx
+++ b/src/pods/test-fill-gap/test-fill-gap.component.tsx
@@ -7,6 +7,7 @@ import { Formik, Form } from 'formik';
 import { GapComponent, ShowResultsComponent } from './components';
 import { answerIsCorrect } from './test-fill-gap.business';
 import * as styles from 'common/styles/tests.styles';
+import { Pronunciation } from "common/components";
 
 interface Props {
   currentQuestion: number;
@@ -59,6 +60,10 @@ export const TestFillGapComponent: React.FC<Props> = props => {
     onNextQuestion();
   }
 
+  const textToSpeech = ():string => {
+    return `${verb.infinitive}. ${verb.past}. ${verb.participle}`;
+  };
+
   return (
     <main className={mainContainer}>
       <h1 className={title}>
@@ -101,6 +106,7 @@ export const TestFillGapComponent: React.FC<Props> = props => {
                     tense={"Participle"}
                   />
                 </div>
+                <Pronunciation text={textToSpeech()}/>
               </div>
             )}
             {validated ? (

--- a/src/pods/test-verb-forms/test-verb-forms.component.tsx
+++ b/src/pods/test-verb-forms/test-verb-forms.component.tsx
@@ -13,6 +13,7 @@ import { TextFieldComponent } from 'common/components';
 import { answerIsCorrect } from './test-verb-forms.business';
 import { ShowResults } from './components';
 import * as classes from 'common/styles/tests.styles';
+import { Pronunciation } from "common/components";
 
 interface Props {
   currentQuestion: number;
@@ -81,6 +82,10 @@ export const TestVerbFormComponent: React.FC<Props> = props => {
     setSecondAttempt(true);
   };
 
+  const textToSpeech = ():string => {
+    return `${verb.infinitive}. ${verb.past}. ${verb.participle}`;
+  };
+
   return (
     <main className={mainContainer}>
       <h1 className={title}>
@@ -142,6 +147,7 @@ export const TestVerbFormComponent: React.FC<Props> = props => {
                     />
                   </div>
                 </div>
+                <Pronunciation text={textToSpeech()}/>
               </div>
             )}
             {validated &&
@@ -181,16 +187,18 @@ export const TestVerbFormComponent: React.FC<Props> = props => {
                 </Button>
               </>
             ) : (
-              <Button
-                className={nextBtn}
-                type="submit"
-                variant="contained"
-                disableElevation
-              >
-                <div className={insideBtnContainer}>
-                  Next <ArrowForwardIcon className={arrowIcon} />
-                </div>
-              </Button>
+              <>
+                <Button
+                  className={nextBtn}
+                  type="submit"
+                  variant="contained"
+                  disableElevation
+                >
+                  <div className={insideBtnContainer}>
+                    Next <ArrowForwardIcon className={arrowIcon} />
+                  </div>
+                </Button>
+              </>
             )}
           </Form>
         )}


### PR DESCRIPTION
Pull request for issue #32 - Integrate pronunciation.
A tiny button has been included in both tests, as shown below:
![image](https://user-images.githubusercontent.com/33926302/113189575-a2722180-925b-11eb-9171-ca99f95bab6b.png)

- This pronunciation button has been componetised and promoted to common under folder __src/common/components/pronunciation/__.
- Also some unit tests have been written in order to check component's logic (__src/common/components/pronunciation/pronunciation.business.ts__).
- Two new members have been added to customPalette (__src/core/theme/theme.vm.ts__): _volumeLight_ and _volumeDark_.

If you have any doubts or you think I should change anything, please tell me.