### PR TITLE
Trim answers.  Create common business functions

### DIFF
--- a/src/common/business/index.ts
+++ b/src/common/business/index.ts
@@ -1,0 +1,3 @@
+export * from './low-object';
+export * from './map-object';
+export * from './trim-object';

--- a/src/common/business/low-object.spec.ts
+++ b/src/common/business/low-object.spec.ts
@@ -1,0 +1,76 @@
+import { lowObject } from './low-object';
+
+describe('low-object specs', () => {
+    describe('Edge scenarios', () => {
+        it('Should return null if original object is null', () => {
+            //Arrange
+
+            //Act
+            const result = lowObject(null, null);
+
+            //Assert
+            expect(result).toBeNull();
+        })
+
+        it('Should return null if original object is undefined', () => {
+            //Arrange
+
+            //Act
+            const result = lowObject(undefined, null);
+
+            //Assert
+            expect(result).toBeNull();
+        })
+
+        it('Should return an empty object if original object is empty', () => {
+            //Arrange
+            const originalObject = {}
+
+            //Act
+            const result = lowObject(originalObject, null);
+
+            //Assert
+            expect(result === originalObject).toBeFalsy();
+            expect(Object.entries(result)).toHaveLength(0);
+        })
+    })
+
+    describe('Regular scenarios', () => {
+        it('Should return a copy of original object where each field has been low-cased if targetProperties is null', () => {
+            //Arrange
+            const originalObject = { a: 'myValue' }
+
+            //Act
+            const result = lowObject(originalObject, null);
+
+            //Assert
+            expect(result === originalObject).toBeFalsy();
+            expect(result.a === originalObject.a.toLowerCase()).toBeTruthy();
+        })
+
+        it('Should return a copy of original object where each field is equal to original object if targetProperties is []', () => {
+            //Arrange
+            const originalObject = { a: 'myValue' }
+
+            //Act
+            const result = lowObject(originalObject, []);
+
+            //Assert
+            expect(result === originalObject).toBeFalsy();
+            expect(result.a === originalObject.a).toBeTruthy();
+        })
+
+        it('Should return a copy of original object where each field present in targetProperties has been low-cased', () => {
+            //Arrange
+            const originalObject = { a: 'myValue', b: 'myOtherValue' }
+
+            //Act
+            const result = lowObject(originalObject, ['a']);
+
+            //Assert
+            expect(result === originalObject).toBeFalsy();
+            expect(result.a === originalObject.a.toLowerCase()).toBeTruthy();
+            expect(result.b === originalObject.b).toBeTruthy();
+        })
+    })
+})

--- a/src/common/business/low-object.ts
+++ b/src/common/business/low-object.ts
@@ -1,0 +1,5 @@
+import { mapObject } from './map-object';
+
+export const lowObject = <T>(originalObject: T, targetProperties: String[] = null): T => {
+    return <T>mapObject(originalObject, (value: String) => value?.toLowerCase(), targetProperties);
+}

--- a/src/common/business/map-object.spec.ts
+++ b/src/common/business/map-object.spec.ts
@@ -1,0 +1,91 @@
+import { mapObject } from './map-object';
+
+describe('map-object specs', () => {
+    describe('Edge scenarios', () => {
+        it('Should return null if original object is null', () => {
+            //Arrange
+
+            //Act
+            const result = mapObject(null, null, null);
+
+            //Assert
+            expect(result).toBeNull();
+        })
+
+        it('Should return null if original object is undefined', () => {
+            //Arrange
+
+            //Act
+            const result = mapObject(undefined, null, null);
+
+            //Assert
+            expect(result).toBeNull();
+        })
+
+        it('Should return an empty object if original object is empty', () => {
+            //Arrange
+            const originalObject = {}
+
+            //Act
+            const result = mapObject(originalObject, null, null);
+
+            //Assert
+            expect(result === originalObject).toBeFalsy();
+            expect(Object.entries(result)).toHaveLength(0);
+        })
+
+        it('Should return a copy of original object, but not the original, if mapper function is null', () => {
+            //Arrange
+            const originalObject = { a: 'myValue' }
+
+            //Act
+            const result = mapObject(originalObject, null, null);
+
+            //Assert
+            expect(result === originalObject).toBeFalsy();
+            expect(result.a === originalObject.a).toBeTruthy();
+        })
+    })
+
+    describe('Regular scenarios', () => {
+        it('Should return a copy of original object where each field has been mapped if targetProperties is null', () => {
+            //Arrange
+            const originalObject = { a: 'myValue' }
+            const mapper = (value: String) => value.toUpperCase();
+
+            //Act
+            const result = mapObject(originalObject, mapper, null);
+
+            //Assert
+            expect(result === originalObject).toBeFalsy();
+            expect(result.a === mapper(originalObject.a)).toBeTruthy();
+        })
+
+        it('Should return a copy of original object where each field is equal to original object if targetProperties is []', () => {
+            //Arrange
+            const originalObject = { a: 'myValue' }
+            const mapper = (value: String) => value.toUpperCase();
+
+            //Act
+            const result = mapObject(originalObject, mapper, []);
+
+            //Assert
+            expect(result === originalObject).toBeFalsy();
+            expect(result.a === originalObject.a).toBeTruthy();
+        })
+
+        it('Should return a copy of original object where each field present in targetProperties has been mapped', () => {
+            //Arrange
+            const originalObject = { a: 'myValue', b: 'myOtherValue' }
+            const mapper = (value: String) => value.toUpperCase();
+
+            //Act
+            const result = mapObject(originalObject, mapper, ['a']);
+
+            //Assert
+            expect(result === originalObject).toBeFalsy();
+            expect(result.a === mapper(originalObject.a)).toBeTruthy();
+            expect(result.b === originalObject.b).toBeTruthy();
+        })
+    })
+})

--- a/src/common/business/map-object.ts
+++ b/src/common/business/map-object.ts
@@ -1,5 +1,5 @@
 export const mapObject = <T>(originalObject: T, mapper: (value: any) => any, targetProperties: String[] = null): T => {
-    const trimmedObject = Object.entries(originalObject).reduce((acc, cur) => {
+    const mappedObject = Object.entries(originalObject).reduce((acc, cur) => {
         const [key, value] = cur;
 
         if (targetProperties === null || targetProperties.some(prop => key === prop)) {
@@ -11,5 +11,5 @@ export const mapObject = <T>(originalObject: T, mapper: (value: any) => any, tar
         return acc;
     }, {})
 
-    return <T>trimmedObject;
+    return <T>mappedObject;
 }

--- a/src/common/business/map-object.ts
+++ b/src/common/business/map-object.ts
@@ -1,8 +1,10 @@
-export const mapObject = <T>(originalObject: T, mapper: (value: any) => any, targetProperties: String[] = null): T => {
+export const mapObject = <T, S>(originalObject: T, mapper: (value: S) => S, targetProperties: String[] = null): T => {
+    if (!originalObject) return null;
+
     const mappedObject = Object.entries(originalObject).reduce((acc, cur) => {
         const [key, value] = cur;
 
-        if (targetProperties === null || targetProperties.some(prop => key === prop)) {
+        if (!!mapper && (targetProperties === null || targetProperties.some(prop => key === prop))) {
             acc[key] = mapper(value);
         } else {
             acc[key] = value;

--- a/src/common/business/map-object.ts
+++ b/src/common/business/map-object.ts
@@ -1,0 +1,15 @@
+export const mapObject = <T>(originalObject: T, mapper: (value: any) => any, targetProperties: String[] = null): T => {
+    const trimmedObject = Object.entries(originalObject).reduce((acc, cur) => {
+        const [key, value] = cur;
+
+        if (targetProperties === null || targetProperties.some(prop => key === prop)) {
+            acc[key] = mapper(value);
+        } else {
+            acc[key] = value;
+        }
+
+        return acc;
+    }, {})
+
+    return <T>trimmedObject;
+}

--- a/src/common/business/trim-object.spec.ts
+++ b/src/common/business/trim-object.spec.ts
@@ -1,0 +1,76 @@
+import { trimObject } from './trim-object';
+
+describe('trim-object specs', () => {
+    describe('Edge scenarios', () => {
+        it('Should return null if original object is null', () => {
+            //Arrange
+
+            //Act
+            const result = trimObject(null, null);
+
+            //Assert
+            expect(result).toBeNull();
+        })
+
+        it('Should return null if original object is undefined', () => {
+            //Arrange
+
+            //Act
+            const result = trimObject(undefined, null);
+
+            //Assert
+            expect(result).toBeNull();
+        })
+
+        it('Should return an empty object if original object is empty', () => {
+            //Arrange
+            const originalObject = {}
+
+            //Act
+            const result = trimObject(originalObject, null);
+
+            //Assert
+            expect(result === originalObject).toBeFalsy();
+            expect(Object.entries(result)).toHaveLength(0);
+        })
+    })
+
+    describe('Regular scenarios', () => {
+        it('Should return a copy of original object where each field has been trimmed if targetProperties is null', () => {
+            //Arrange
+            const originalObject = { a: ' myValue ' }
+
+            //Act
+            const result = trimObject(originalObject, null);
+
+            //Assert
+            expect(result === originalObject).toBeFalsy();
+            expect(result.a === originalObject.a.trim()).toBeTruthy();
+        })
+
+        it('Should return a copy of original object where each field is equal to original object if targetProperties is []', () => {
+            //Arrange
+            const originalObject = { a: ' myValue ' }
+
+            //Act
+            const result = trimObject(originalObject, []);
+
+            //Assert
+            expect(result === originalObject).toBeFalsy();
+            expect(result.a === originalObject.a).toBeTruthy();
+        })
+
+        it('Should return a copy of original object where each field present in targetProperties has been trimmed', () => {
+            //Arrange
+            const originalObject = { a: ' myValue ', b: ' myOtherValue ' }
+
+            //Act
+            const result = trimObject(originalObject, ['a']);
+
+            //Assert
+            expect(result === originalObject).toBeFalsy();
+            expect(result.a === originalObject.a.trim()).toBeTruthy();
+            expect(result.b === originalObject.b).toBeTruthy();
+        })
+    })
+})

--- a/src/common/business/trim-object.ts
+++ b/src/common/business/trim-object.ts
@@ -1,0 +1,5 @@
+import { mapObject } from './map-object';
+
+export const trimObject = <T>(originalObject: T, targetProperties: String[] = null): T => {
+    return <T>mapObject(originalObject, (value: String) => value?.trim(), targetProperties);
+}

--- a/src/pods/test-fill-gap/test-fill-gap.business.ts
+++ b/src/pods/test-fill-gap/test-fill-gap.business.ts
@@ -1,5 +1,6 @@
 import { VerbEntityGlobal } from 'core/verbs';
 import { Verb, VerbQuiz, VerbTenses } from './test-fill-gap.vm';
+import { trimObject, lowObject } from 'common/business';
 
 // TODO: maybe add some defensive programming here? edge cases / errors ?
 export const pickRandomVerb = (
@@ -20,21 +21,10 @@ export const pickRandomVerb = (
   };
 };
 
-const verbToLower = (verb: Verb): Verb => ({
-  infinitive: verb.infinitive.toLowerCase(),
-  past: verb.past.toLowerCase(),
-  participle: verb.participle.toLowerCase(),
-  translation: verb.translation.toLowerCase(),
-});
-
-const quizToLower = (quiz: VerbQuiz) => ({
-  ...quiz,
-  response: quiz.response.toLowerCase(),
-});
-
 export const answerIsCorrect = (verb: Verb, quiz: VerbQuiz): boolean => {
-  const verbLower = verbToLower(verb);
-  const quizLower = quizToLower(quiz);
+  const verbLower = lowObject(verb);
+  const quizTrimmed = trimObject(quiz, ['response']);
+  const quizLower = lowObject(quizTrimmed, ['response']);
 
   return quizLower.tense === VerbTenses.infinitive ? verbLower.infinitive === quizLower.response :
     quizLower.tense === VerbTenses.past ? verbLower.past === quizLower.response :

--- a/src/pods/test-verb-forms/test-verb-forms.business.ts
+++ b/src/pods/test-verb-forms/test-verb-forms.business.ts
@@ -1,5 +1,6 @@
 import { VerbEntityGlobal } from 'core/verbs';
 import { Verb, VerbQuiz, VerbCorrect, createDefaultVerbCorrect } from './test-verb-forms.vm';
+import { trimObject, lowObject } from 'common/business';
 
 // TODO: maybe add some defensive programming here? edge cases / errors ?
 export const pickRandomVerb = (
@@ -20,22 +21,10 @@ export const pickRandomVerb = (
   };
 };
 
-const verbToLower = (verb: Verb): Verb => ({
-  infinitive: verb.infinitive.toLowerCase(),
-  past: verb.past.toLowerCase(),
-  participle: verb.participle.toLowerCase(),
-  translation: verb.translation.toLowerCase(),
-});
-
-const quizToLower = (quiz: VerbQuiz) => ({
-  past: quiz.past.toLowerCase(),
-  participle: quiz.participle.toLowerCase(),
-  infinitive: quiz.infinitive.toLowerCase(),
-});
-
 export const answerIsCorrect = (verb: Verb, quiz: VerbQuiz): VerbCorrect => {
-  const verbLower = verbToLower(verb);
-  const quizLower = quizToLower(quiz);
+  const verbLower = lowObject(verb);
+  const quizTrimmed = trimObject(quiz);
+  const quizLower = lowObject(quizTrimmed);
 
   let verbCorrect = createDefaultVerbCorrect();
   verbCorrect.infinitive = verbLower.infinitive === quizLower.infinitive;
@@ -47,10 +36,10 @@ export const answerIsCorrect = (verb: Verb, quiz: VerbQuiz): VerbCorrect => {
 
 export const generateHint = (verbCorrect: VerbCorrect) => {
   // TODO: Magic consts move to upper const file
-  const infinitive = (!verbCorrect.infinitive) ? 'infinitive'  : '';
+  const infinitive = (!verbCorrect.infinitive) ? 'infinitive' : '';
   const past = (!verbCorrect.past) ? 'past' : '';
-  const participle = (!verbCorrect.participle) ? 'participle': '';
-  
+  const participle = (!verbCorrect.participle) ? 'participle' : '';
+
   return removeBeginningAndTrailingCommaIfExists(`${infinitive}, ${past}, ${participle}`);
 };
 
@@ -58,6 +47,6 @@ const removeBeginningAndTrailingCommaIfExists = (hint: string) => {
   hint = hint.trim();
   hint = hint.replace(", ,", ","); //To remove double comma
   hint = hint[0] === ',' ? hint.substring(2, hint.length) : hint; //To remove beginning comma
-  hint = hint[hint.length-1] === ',' ? hint.substring(0, hint.length-1) : hint; //To remove trailing comma
+  hint = hint[hint.length - 1] === ',' ? hint.substring(0, hint.length - 1) : hint; //To remove trailing comma
   return hint;
 }


### PR DESCRIPTION
Created common generic business functions to:
- Convert objects with string properties to lower case
- Convert objects with string properties to have trimmed values.

Applied on verb-test and fill-gap components.