### PR TITLE
Tests navbar

### DIFF
--- a/src/common/components/index.ts
+++ b/src/common/components/index.ts
@@ -1,2 +1,3 @@
 export * from './form';
 export * from './pronunciation';
+export * from './tests-navbar';

--- a/src/common/components/tests-navbar/components/finish-test.component.tsx
+++ b/src/common/components/tests-navbar/components/finish-test.component.tsx
@@ -20,7 +20,13 @@ export const FinishTest: React.FC<Props> = props => {
   const [open, setOpen] = React.useState(false);
   const { setScore } = React.useContext(scoreContext);
   const history = useHistory();
-  const { finishBtn } = classes;
+  const {
+    finishBtn,
+    dialogTitle,
+    dialogContent,
+    dialogNoBtn,
+    dialogYesBtn,
+  } = classes;
 
   const handleOpenDialog = () => {
     setOpen(true);
@@ -49,22 +55,29 @@ export const FinishTest: React.FC<Props> = props => {
       <Dialog
         open={open}
         onClose={handleCloseDialog}
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-description"
       >
-        <DialogTitle>
-          Finish the test earlier?
+        <DialogTitle className={dialogTitle}>
+          Are you sure you want to cancel this test?
         </DialogTitle>
         <DialogContent>
-          <DialogContentText id="alert-dialog-description">
-            If you want to finish the test before answering all the questions please press button 'YES'.
+          <DialogContentText className={dialogContent}>
+            If you want to finish the test before answering all the questions please press 'Yes'.
+            Otherwise press 'No'.
           </DialogContentText>
         </DialogContent>
         <DialogActions>
           <Button
+            className={dialogNoBtn}
+            onClick={handleCloseDialog}
+            variant="contained"
+            disableElevation
+          >
+            No
+          </Button>
+          <Button
+            className={dialogYesBtn}
             onClick={handleFinishTest}
             variant="contained"
-            color="primary"
             disableElevation
           >
             Yes

--- a/src/common/components/tests-navbar/components/finish-test.component.tsx
+++ b/src/common/components/tests-navbar/components/finish-test.component.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import { scoreContext } from 'core/score';
+import { useHistory } from 'react-router-dom';
+import { routes } from 'core/router';
+import * as classes from './finish-test.styles';
+
+interface Props {
+  score: number;
+  currentQuestion: number;
+}
+
+export const FinishTest: React.FC<Props> = props => {
+  const { score, currentQuestion } = props;
+  const [open, setOpen] = React.useState(false);
+  const { setScore } = React.useContext(scoreContext);
+  const history = useHistory();
+  const { finishBtn } = classes;
+
+  const handleOpenDialog = () => {
+    setOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setOpen(false);
+  };
+
+  const handleFinishTest = () => {
+    // Set current score before navigating to 'finalScore'
+    setScore({ totalQuestions: currentQuestion, answeredCorrectly: score});
+    history.push(routes.finalScore);
+  };
+
+  return (
+    <>
+      <Button
+        className={finishBtn}
+        onClick={handleOpenDialog}
+        variant="contained"
+        disableElevation  
+      >
+        Finish test
+      </Button>
+      <Dialog
+        open={open}
+        onClose={handleCloseDialog}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle>
+          Finish the test earlier?
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            If you want to finish the test before answering all the questions please press button 'YES'.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={handleFinishTest}
+            variant="contained"
+            color="primary"
+            disableElevation
+          >
+            Yes
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};

--- a/src/common/components/tests-navbar/components/finish-test.styles.ts
+++ b/src/common/components/tests-navbar/components/finish-test.styles.ts
@@ -10,6 +10,23 @@ export const finishBtn = css`
   text-transform: capitalize;
   font-weight: 700;
   font-size: 1.2rem;
+  color: #1976d2;
+  background-color: ${color.lightWhite};
+  transition: all 0.2s;
+  --webkit-transition: all 0.2s;
+  &:hover,
+  &:active {
+    outline: none;
+    background-color: #E3F0FF;
+  }
+`;
+
+export const dialogNoBtn = css`
+  border-radius: 1.4rem;
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  text-transform: capitalize;
+  font-weight: 700;
+  font-size: 1.2rem;
   color: ${color.lightWhite};
   background-color: ${color.primaryMain};
   transition: all 0.2s;
@@ -19,4 +36,31 @@ export const finishBtn = css`
     outline: none;
     background-color: ${color.primaryDark};
   }
+`;
+
+export const dialogYesBtn = css`
+  border-radius: 1.4rem;
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  text-transform: capitalize;
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: ${color.lightWhite};
+  background-color: #1976d2;
+  transition: all 0.2s;
+  --webkit-transition: all 0.2s;
+  &:hover,
+  &:active {
+    outline: none;
+    background-color: #115293;
+  }
+`;
+
+export const dialogTitle = css`
+  font-size: 1.6rem;
+  text-align: center;
+`;
+
+export const dialogContent = css`
+  display: block;
+  font-size: 1.2rem;
 `;

--- a/src/common/components/tests-navbar/components/finish-test.styles.ts
+++ b/src/common/components/tests-navbar/components/finish-test.styles.ts
@@ -1,0 +1,22 @@
+import { css } from 'emotion';
+import { theme } from 'core/theme';
+
+const { palette, spacing, breakpoints } = theme;
+const color = palette.customPalette;
+
+export const finishBtn = css`
+  border-radius: 1.4rem;
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  text-transform: capitalize;
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: ${color.lightWhite};
+  background-color: ${color.primaryMain};
+  transition: all 0.2s;
+  --webkit-transition: all 0.2s;
+  &:hover,
+  &:active {
+    outline: none;
+    background-color: ${color.primaryDark};
+  }
+`;

--- a/src/common/components/tests-navbar/components/index.ts
+++ b/src/common/components/tests-navbar/components/index.ts
@@ -1,0 +1,1 @@
+export * from './finish-test.component';

--- a/src/common/components/tests-navbar/index.ts
+++ b/src/common/components/tests-navbar/index.ts
@@ -1,0 +1,1 @@
+export * from './tests-navbar.component';

--- a/src/common/components/tests-navbar/tests-navbar.component.tsx
+++ b/src/common/components/tests-navbar/tests-navbar.component.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import * as styles from './tests-navbar.styles';
+import { FinishTest } from "./components";
+
+interface Props {
+  score: number;
+  currentQuestion: number;
+}
+
+export const TestsNavbar: React.FC<Props> = props => {
+  const { score, currentQuestion } = props;
+  const {
+    appBarDiv,
+    appBarTitle,
+  } = styles;
+
+  return (
+    <div className={appBarDiv}>
+      <AppBar position="absolute">
+        <Toolbar>
+          <span className={appBarTitle}>
+            Score: {score}/{currentQuestion}
+          </span>
+          <FinishTest score={score} currentQuestion={currentQuestion}/>
+        </Toolbar>
+      </AppBar>
+    </div>
+  );
+}

--- a/src/common/components/tests-navbar/tests-navbar.styles.ts
+++ b/src/common/components/tests-navbar/tests-navbar.styles.ts
@@ -1,0 +1,18 @@
+import { css } from 'emotion';
+import { theme } from 'core/theme';
+
+const { palette, spacing, breakpoints } = theme;
+const color = palette.customPalette;
+
+export const appBarDiv = css`
+  flex-grow: 1;
+  margin-bottom: 20%;
+`;
+
+export const appBarTitle = css`
+  flex-grow: 1;
+  font-size: 1.6rem;
+  @media (min-width: ${breakpoints.values.xs}px) {
+    font-size: 1.75rem;
+  }
+`;

--- a/src/pods/test-fill-gap/test-fill-gap.component.tsx
+++ b/src/pods/test-fill-gap/test-fill-gap.component.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import Button from '@material-ui/core/Button';
-import Typography from '@material-ui/core/Typography';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import { Verb, VerbTenses, VerbQuiz, createDefaultVerbQuiz } from "./test-fill-gap.vm";
 import { Formik, Form } from 'formik';
 import { GapComponent, ShowResultsComponent } from './components';
 import { answerIsCorrect } from './test-fill-gap.business';
 import * as styles from 'common/styles/tests.styles';
-import { Pronunciation } from "common/components";
+import { Pronunciation, TestsNavbar } from "common/components";
 
 interface Props {
   currentQuestion: number;
@@ -69,6 +68,7 @@ export const TestFillGapComponent: React.FC<Props> = props => {
 
   return (
     <main className={mainContainer}>
+      <TestsNavbar score={score} currentQuestion={currentQuestion} />
       <h1 className={title}>
         {verb.translation} ({`${currentQuestion} / ${totalQuestions}`})
       </h1>

--- a/src/pods/test-verb-forms/test-verb-forms.component.tsx
+++ b/src/pods/test-verb-forms/test-verb-forms.component.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Typography, Button } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import {
   Verb,
@@ -9,11 +9,10 @@ import {
   createDefaultVerbCorrect,
 } from './test-verb-forms.vm';
 import { Formik, Form, Field } from 'formik';
-import { TextFieldComponent } from 'common/components';
 import { answerIsCorrect } from './test-verb-forms.business';
 import { ShowResults } from './components';
 import * as classes from 'common/styles/tests.styles';
-import { Pronunciation } from "common/components";
+import { Pronunciation, TestsNavbar } from "common/components";
 
 interface Props {
   currentQuestion: number;
@@ -91,6 +90,7 @@ export const TestVerbFormComponent: React.FC<Props> = props => {
 
   return (
     <main className={mainContainer}>
+      <TestsNavbar score={score} currentQuestion={currentQuestion} />
       <h1 className={title}>
         {verb.translation} ({`${currentQuestion} / ${totalQuestions}`})
       </h1>


### PR DESCRIPTION
New feature that adds a navbar during tests. This navbar:

- Shows user's current score
- Includes a button that allows to finish the test earlier. Pressing this button will prompt a dialog to confirm test end.

A couple of screenshots are included in order to clarify the new feature.

![image](https://user-images.githubusercontent.com/33926302/113767947-8f5dc680-971f-11eb-8dd2-3e8e8ec3446a.png)

![image](https://user-images.githubusercontent.com/33926302/113768291-fa0f0200-971f-11eb-9fbf-449932a0cf41.png)

