### PR TITLE
Fixed pronunciation button shape

### DIFF
--- a/src/common/components/pronunciation/pronunciation.styles.ts
+++ b/src/common/components/pronunciation/pronunciation.styles.ts
@@ -11,7 +11,7 @@ export const pronunciationContainer = css`
 `;
 
 export const volumeIcon = css`
-  width: ${spacing(4)};
+  width: ${spacing(6)};
   color: ${color.lightWhite};
   background-color: ${color.volumeLight};
   transition: all 0.2s;
@@ -20,8 +20,5 @@ export const volumeIcon = css`
   &:active {
     outline: none;
     background-color: ${color.volumeDark};
-  }
-  @media (min-width: ${breakpoints.values.xs}px) {
-    width: ${spacing(6)};
   }
 `;

--- a/src/pods/home/home.component.tsx
+++ b/src/pods/home/home.component.tsx
@@ -35,7 +35,7 @@ export const HomeComponent = () => {
         </Button>
         <Button className={homeButton} variant="contained">
           <Link to={routes.testFillGap} className={homeLink}>
-            Start Test 'Fill the gap'
+            Start Test<br/>'Fill the gap'
           </Link>
         </Button>
         <Button className={homeButton} variant="contained">


### PR DESCRIPTION
Pronuciation button shape on xs devices was not a circle. I fixed it.
I've also added a line break in the text of fill the gap button. Now, the name of the test is not on two different lines.
![image](https://user-images.githubusercontent.com/33926302/115996306-0e3b7600-a5df-11eb-97c2-330af0baedac.png)
