### PR TITLE
fix: change total final score

### DIFF
--- a/src/common/components/tests-navbar/components/finish-test.component.tsx
+++ b/src/common/components/tests-navbar/components/finish-test.component.tsx
@@ -8,17 +8,19 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import { scoreContext } from 'core/score';
 import { useHistory } from 'react-router-dom';
 import { routes } from 'core/router';
+import { settingsContext } from 'core/settings';
 import * as classes from './finish-test.styles';
 
 interface Props {
   score: number;
-  currentQuestion: number;
 }
 
 export const FinishTest: React.FC<Props> = props => {
-  const { score, currentQuestion } = props;
-  const [open, setOpen] = React.useState(false);
+  const { score } = props;
+  const { userSettings } = React.useContext(settingsContext);
   const { setScore } = React.useContext(scoreContext);
+  const [open, setOpen] = React.useState(false);
+  const [totalQuestions] = React.useState(userSettings.numberQuestions);
   const history = useHistory();
   const {
     finishBtn,
@@ -38,7 +40,7 @@ export const FinishTest: React.FC<Props> = props => {
 
   const handleFinishTest = () => {
     // Set current score before navigating to 'finalScore'
-    setScore({ totalQuestions: currentQuestion, answeredCorrectly: score});
+    setScore({ totalQuestions, answeredCorrectly: score});
     history.push(routes.finalScore);
   };
 
@@ -48,7 +50,7 @@ export const FinishTest: React.FC<Props> = props => {
         className={finishBtn}
         onClick={handleOpenDialog}
         variant="contained"
-        disableElevation  
+        disableElevation
       >
         Finish test
       </Button>

--- a/src/common/components/tests-navbar/tests-navbar.component.tsx
+++ b/src/common/components/tests-navbar/tests-navbar.component.tsx
@@ -23,7 +23,7 @@ export const TestsNavbar: React.FC<Props> = props => {
           <span className={appBarTitle}>
             Score: {score}/{currentQuestion}
           </span>
-          <FinishTest score={score} currentQuestion={currentQuestion}/>
+          <FinishTest score={score}/>
         </Toolbar>
       </AppBar>
     </div>


### PR DESCRIPTION
Fixed the total number of questions in final screen and changed it to appear the number of questions of the user settings.
According to issue [#64 ](https://github.com/Lemoncode/english-quiz/issues/64)
@JTrillo @brauliodiez 