### PR TITLE
FIXED:  [Low hanging fruit] Fix Typo #83

### DIFF
--- a/src/core/verbs/global-verbs.storage.ts
+++ b/src/core/verbs/global-verbs.storage.ts
@@ -669,7 +669,7 @@ export const defaultFullVerbs = [
     infinitive: 'spend',
     past: 'spent',
     participle: 'spent',
-    translation: 'pasar, gastar',
+    translation: 'pagar, gastar',
   },
   {
     infinitive: 'spill',


### PR DESCRIPTION
Changed 'pasar, gastar' to 'pagar, gastar' on 'const defaultFullVerbs'